### PR TITLE
Adds persistent storage support

### DIFF
--- a/rootfs/init
+++ b/rootfs/init
@@ -41,6 +41,11 @@ udhcpc -f -p /var/run/udhcpc.pid > /var/log/udhcpc.log 2>&1 &
 dropbear -B -R > /var/log/dropbear.log 2>&1
 
 # Start docker
+DOCKER_DATA="$(blkid | grep 'LABEL="DOCKER_DATA"' | awk -F ':' '{ print $1 }')"
+if [ "$DOCKER_DATA" ]; then
+  mkdir -p /var/lib/docker
+  mount "$DOCKER_DATA" /var/lib/docker
+fi
 DOCKER_RAMDISK=true dockerd -p /var/run/docker.pid > /var/log/docker.log 2>&1 &
 
 echo -e "\nBoot took $(cut -d' ' -f1 /proc/uptime) seconds\n"


### PR DESCRIPTION
This looks for a block device labelled `DOCKER_DATA` and uses this as the
storage for `/var/lib/docker`.

Closes #3